### PR TITLE
Add GitHub Skills Activity - Fixes #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Fixes Issue #6: Missing Activity: GitHub Skills

### Changes Made
- Added the GitHub Skills activity to the activities list in `src/app.py`
- Configured with appropriate schedule (Mondays and Thursdays, 3:30 PM - 4:30 PM)
- Set capacity to 25 participants to accommodate high demand
- Added comprehensive description mentioning GitHub Certifications program

### Context
This addresses the urgent issue reported by students who couldn't find the GitHub Skills activity that was announced by the principal. The activity is part of the GitHub Certifications program to help with college applications, and registrations are closing by the end of this week.

### Testing
- ✅ Application runs successfully
- ✅ GitHub Skills activity appears in the activities list
- ✅ Students can now register for the activity

Closes #6